### PR TITLE
Fixed permissions of copied directories. 

### DIFF
--- a/core/src/main/java/com/hivemq/testcontainer/core/HiveMQTestContainerCore.java
+++ b/core/src/main/java/com/hivemq/testcontainer/core/HiveMQTestContainerCore.java
@@ -149,7 +149,7 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
     public @NotNull SELF withExtension(final @NotNull HiveMQExtension hiveMQExtension) {
         try {
             final File extension = createExtension(hiveMQExtension);
-            final MountableFile mountableExtension = MountableFile.forHostPath(extension.getPath());
+            final MountableFile mountableExtension = MountableFile.forHostPath(extension.getPath(), 32767);
             withCopyFileToContainer(mountableExtension, "/opt/hivemq/extensions/" + hiveMQExtension.getId());
         } catch (final Exception e) {
             e.printStackTrace();
@@ -176,7 +176,7 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
             return self();
         }
         try {
-            final MountableFile mountableExtension = MountableFile.forHostPath(extensionDir.getPath());
+            final MountableFile mountableExtension = MountableFile.forHostPath(extensionDir.getPath(), 32767);
             final String containerPath = "/opt/hivemq/extensions/" + extensionDir.getName();
             withCopyFileToContainer(mountableExtension, containerPath);
             logger.info("Putting extension {} into {}", extensionDir.getName(), containerPath);
@@ -267,7 +267,7 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
             logger.warn("License file {} does not end wit '.lic' or '.elic'", license.getAbsolutePath());
             return self();
         }
-        final MountableFile mountableFile = MountableFile.forHostPath(license.getAbsolutePath());
+        final MountableFile mountableFile = MountableFile.forHostPath(license.getAbsolutePath(), 32767);
         final String containerPath = "/opt/hivemq/license/" + license.getName();
         withCopyFileToContainer(mountableFile, containerPath);
         logger.info("Putting license {} into {}", license.getAbsolutePath(), containerPath);
@@ -287,7 +287,7 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
             logger.warn("HiveMQ config file {} does not exist.", config.getAbsolutePath());
             return self();
         }
-        final MountableFile mountableFile = MountableFile.forHostPath(config.getAbsolutePath());
+        final MountableFile mountableFile = MountableFile.forHostPath(config.getAbsolutePath(), 32767);
         final String containerPath = "/opt/hivemq/conf/config.xml";
         withCopyFileToContainer(mountableFile, containerPath);
         logger.info("Putting {} into {}", config.getAbsolutePath(), containerPath);
@@ -359,7 +359,7 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
             logger.warn("File {} does not exist.", file.getAbsolutePath());
             return self();
         }
-        final MountableFile mountableFile = MountableFile.forHostPath(file.getAbsolutePath());
+        final MountableFile mountableFile = MountableFile.forHostPath(file.getAbsolutePath(), 32767);
         final String containerPath = "/opt/hivemq" + PathUtil.preparePath(pathInHomeFolder) + file.getName();
         withCopyFileToContainer(mountableFile, containerPath);
         logger.info("Putting file {} into container path {}", file.getAbsolutePath(), containerPath);

--- a/junit4/src/test/java/com/hivemq/testcontainer/junit4/ContainerWithLicenseIT.java
+++ b/junit4/src/test/java/com/hivemq/testcontainer/junit4/ContainerWithLicenseIT.java
@@ -41,7 +41,7 @@ public class ContainerWithLicenseIT {
 
     @Rule
     public final @NotNull HiveMQTestContainerRule extension =
-            new HiveMQTestContainerRule("hivemq/hivemq4", "latest")
+            new HiveMQTestContainerRule()
                     .withExtension(HiveMQExtension.builder()
                             .id("extension-1")
                             .name("my-extension")

--- a/junit4/src/test/java/com/hivemq/testcontainer/junit4/CreateFileInCopiedDirectoryIT.java
+++ b/junit4/src/test/java/com/hivemq/testcontainer/junit4/CreateFileInCopiedDirectoryIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.testcontainer.junit4;
+
+import com.hivemq.extension.sdk.api.ExtensionMain;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStartInput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStartOutput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStopInput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStopOutput;
+import com.hivemq.extension.sdk.api.services.Services;
+import com.hivemq.extension.sdk.api.services.intializer.ClientInitializer;
+import com.hivemq.testcontainer.core.HiveMQExtension;
+import com.hivemq.testcontainer.util.TestPublishModifiedUtil;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.shaded.com.google.common.io.Files;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Yannick Weber
+ */
+public class CreateFileInCopiedDirectoryIT {
+
+    public @Nullable File tempDir = Files.createTempDir();
+
+    private @NotNull File createDirectory() {
+        final File directory = new File(tempDir, "directory");
+        assertTrue(directory.mkdir());
+        final File subdirectory = new File(directory, "sub-directory");
+        assertTrue(subdirectory.mkdir());
+        return directory;
+    }
+
+    @Rule
+    public final @NotNull HiveMQTestContainerRule rule =
+            new HiveMQTestContainerRule()
+                    .withExtension(HiveMQExtension.builder()
+                            .id("extension-1")
+                            .name("my-extension")
+                            .version("1.0")
+                            .mainClass(FileCreatorExtension.class).build())
+                    .withFileInHomeFolder(createDirectory());
+
+    @Test
+    public void test_createFileInCopiedDirectory() throws ExecutionException, InterruptedException {
+        TestPublishModifiedUtil.testPublishModified(rule.getMqttPort());
+    }
+
+    public static class FileCreatorExtension implements ExtensionMain {
+
+        @Override
+        public void extensionStart(@NotNull ExtensionStartInput extensionStartInput, @NotNull ExtensionStartOutput extensionStartOutput) {
+
+            final PublishInboundInterceptor publishInboundInterceptor = (publishInboundInput, publishInboundOutput) -> {
+
+                final File homeFolder = extensionStartInput.getServerInformation().getHomeFolder();
+
+                final File dir = new File(homeFolder, "directory");
+                final File dirFile = new File(dir, "file.txt");
+                final File subDir = new File(dir, "sub-directory");
+                final File subDirFile = new File(subDir, "file.txt");
+
+                try {
+                    if (dirFile.createNewFile() && subDirFile.createNewFile()) {
+                        publishInboundOutput.getPublishPacket().setPayload(ByteBuffer.wrap("modified".getBytes(StandardCharsets.UTF_8)));
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            };
+
+            final ClientInitializer clientInitializer = (initializerInput, clientContext) -> clientContext.addPublishInboundInterceptor(publishInboundInterceptor);
+
+            Services.initializerRegistry().setClientInitializer(clientInitializer);
+        }
+
+        @Override
+        public void extensionStop(@NotNull ExtensionStopInput extensionStopInput, @NotNull ExtensionStopOutput extensionStopOutput) {
+
+        }
+    }
+
+}

--- a/junit4/src/test/java/com/hivemq/testcontainer/junit4/CreateFileInExtensionDirectoryIT.java
+++ b/junit4/src/test/java/com/hivemq/testcontainer/junit4/CreateFileInExtensionDirectoryIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.testcontainer.junit4;
+
+import com.hivemq.extension.sdk.api.ExtensionMain;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStartInput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStartOutput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStopInput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStopOutput;
+import com.hivemq.extension.sdk.api.services.Services;
+import com.hivemq.extension.sdk.api.services.intializer.ClientInitializer;
+import com.hivemq.testcontainer.core.HiveMQExtension;
+import com.hivemq.testcontainer.util.TestPublishModifiedUtil;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author Yannick Weber
+ */
+public class CreateFileInExtensionDirectoryIT {
+
+    @Rule
+    public final @NotNull HiveMQTestContainerRule rule =
+            new HiveMQTestContainerRule()
+                    .withExtension(HiveMQExtension.builder()
+                            .id("extension-1")
+                            .name("my-extension")
+                            .version("1.0")
+                            .mainClass(FileCreatorExtension.class).build());
+
+    @Test(timeout = 500_000)
+    public void test_single_class_extension() throws ExecutionException, InterruptedException {
+        TestPublishModifiedUtil.testPublishModified(rule.getMqttPort());
+    }
+
+    public static class FileCreatorExtension implements ExtensionMain {
+
+        @Override
+        public void extensionStart(@NotNull ExtensionStartInput extensionStartInput, @NotNull ExtensionStartOutput extensionStartOutput) {
+
+            final PublishInboundInterceptor publishInboundInterceptor = (publishInboundInput, publishInboundOutput) -> {
+
+                final File extensionHomeFolder = extensionStartInput.getExtensionInformation().getExtensionHomeFolder();
+
+                final File file = new File(extensionHomeFolder, "myfile.txt");
+                try {
+                    if (file.createNewFile()) {
+                        publishInboundOutput.getPublishPacket().setPayload(ByteBuffer.wrap("modified".getBytes(StandardCharsets.UTF_8)));
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            };
+
+            final ClientInitializer clientInitializer = (initializerInput, clientContext) -> clientContext.addPublishInboundInterceptor(publishInboundInterceptor);
+
+            Services.initializerRegistry().setClientInitializer(clientInitializer);
+        }
+
+        @Override
+        public void extensionStop(@NotNull ExtensionStopInput extensionStopInput, @NotNull ExtensionStopOutput extensionStopOutput) {
+
+        }
+    }
+
+}

--- a/junit5/src/test/java/com/hivemq/testcontainer/junit5/ContainerWithLicenseIT.java
+++ b/junit5/src/test/java/com/hivemq/testcontainer/junit5/ContainerWithLicenseIT.java
@@ -43,7 +43,7 @@ public class ContainerWithLicenseIT {
 
     @RegisterExtension
     public final @NotNull HiveMQTestContainerExtension extension =
-            new HiveMQTestContainerExtension("hivemq/hivemq4", "latest")
+            new HiveMQTestContainerExtension()
                     .withExtension(HiveMQExtension.builder()
                             .id("extension-1")
                             .name("my-extension")

--- a/junit5/src/test/java/com/hivemq/testcontainer/junit5/CreateFileInCopiedDirectoryIT.java
+++ b/junit5/src/test/java/com/hivemq/testcontainer/junit5/CreateFileInCopiedDirectoryIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.testcontainer.junit5;
+
+import com.hivemq.extension.sdk.api.ExtensionMain;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStartInput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStartOutput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStopInput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStopOutput;
+import com.hivemq.extension.sdk.api.services.Services;
+import com.hivemq.extension.sdk.api.services.intializer.ClientInitializer;
+import com.hivemq.testcontainer.core.HiveMQExtension;
+import com.hivemq.testcontainer.util.TestPublishModifiedUtil;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.shaded.com.google.common.io.Files;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Yannick Weber
+ */
+public class CreateFileInCopiedDirectoryIT {
+
+    public @Nullable File tempDir = Files.createTempDir();
+
+    private @NotNull File createDirectory() {
+        final File directory = new File(tempDir, "directory");
+        assertTrue(directory.mkdir());
+        final File subdirectory = new File(directory, "sub-directory");
+        assertTrue(subdirectory.mkdir());
+        return directory;
+    }
+
+    @RegisterExtension
+    public final @NotNull HiveMQTestContainerExtension extension =
+            new HiveMQTestContainerExtension()
+                    .withExtension(HiveMQExtension.builder()
+                            .id("extension-1")
+                            .name("my-extension")
+                            .version("1.0")
+                            .mainClass(FileCreatorExtension.class).build())
+                    .withFileInHomeFolder(createDirectory());
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void test_createFileInCopiedDirectory() throws ExecutionException, InterruptedException {
+        TestPublishModifiedUtil.testPublishModified(extension.getMqttPort());
+    }
+
+    public static class FileCreatorExtension implements ExtensionMain {
+
+        @Override
+        public void extensionStart(@NotNull ExtensionStartInput extensionStartInput, @NotNull ExtensionStartOutput extensionStartOutput) {
+
+            final PublishInboundInterceptor publishInboundInterceptor = (publishInboundInput, publishInboundOutput) -> {
+
+                final File homeFolder = extensionStartInput.getServerInformation().getHomeFolder();
+
+                final File dir = new File(homeFolder, "directory");
+                final File dirFile = new File(dir, "file.txt");
+                final File subDir = new File(dir, "sub-directory");
+                final File subDirFile = new File(subDir, "file.txt");
+
+                try {
+                    if (dirFile.createNewFile() && subDirFile.createNewFile()) {
+                        publishInboundOutput.getPublishPacket().setPayload(ByteBuffer.wrap("modified".getBytes(StandardCharsets.UTF_8)));
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            };
+
+            final ClientInitializer clientInitializer = (initializerInput, clientContext) -> clientContext.addPublishInboundInterceptor(publishInboundInterceptor);
+
+            Services.initializerRegistry().setClientInitializer(clientInitializer);
+        }
+
+        @Override
+        public void extensionStop(@NotNull ExtensionStopInput extensionStopInput, @NotNull ExtensionStopOutput extensionStopOutput) {
+
+        }
+    }
+
+}

--- a/junit5/src/test/java/com/hivemq/testcontainer/junit5/CreateFileInExtensionDirectoryIT.java
+++ b/junit5/src/test/java/com/hivemq/testcontainer/junit5/CreateFileInExtensionDirectoryIT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.testcontainer.junit5;
+
+import com.hivemq.extension.sdk.api.ExtensionMain;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStartInput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStartOutput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStopInput;
+import com.hivemq.extension.sdk.api.parameter.ExtensionStopOutput;
+import com.hivemq.extension.sdk.api.services.Services;
+import com.hivemq.extension.sdk.api.services.intializer.ClientInitializer;
+import com.hivemq.testcontainer.core.HiveMQExtension;
+import com.hivemq.testcontainer.util.TestPublishModifiedUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Yannick Weber
+ */
+public class CreateFileInExtensionDirectoryIT {
+
+    @RegisterExtension
+    public final @NotNull HiveMQTestContainerExtension extension =
+            new HiveMQTestContainerExtension()
+                    .withExtension(HiveMQExtension.builder()
+                            .id("extension-1")
+                            .name("my-extension")
+                            .version("1.0")
+                            .mainClass(FileCreatorExtension.class).build());
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void test_createFileInExtensionDirectory() throws ExecutionException, InterruptedException {
+        TestPublishModifiedUtil.testPublishModified(extension.getMqttPort());
+    }
+
+    public static class FileCreatorExtension implements ExtensionMain {
+
+        @Override
+        public void extensionStart(@NotNull ExtensionStartInput extensionStartInput, @NotNull ExtensionStartOutput extensionStartOutput) {
+
+            final PublishInboundInterceptor publishInboundInterceptor = (publishInboundInput, publishInboundOutput) -> {
+
+                final File extensionHomeFolder = extensionStartInput.getExtensionInformation().getExtensionHomeFolder();
+
+                final File file = new File(extensionHomeFolder, "myfile.txt");
+                try {
+                    if (file.createNewFile()) {
+                        publishInboundOutput.getPublishPacket().setPayload(ByteBuffer.wrap("modified".getBytes(StandardCharsets.UTF_8)));
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            };
+
+            final ClientInitializer clientInitializer = (initializerInput, clientContext) -> clientContext.addPublishInboundInterceptor(publishInboundInterceptor);
+
+            Services.initializerRegistry().setClientInitializer(clientInitializer);
+        }
+
+        @Override
+        public void extensionStop(@NotNull ExtensionStopInput extensionStopInput, @NotNull ExtensionStopOutput extensionStopOutput) {
+
+        }
+    }
+
+}


### PR DESCRIPTION
**Motivation**

Extensions where not able to create files inside of directories that where copied inside the container. 
A 'permission denied' IOException was thrown. 

Resolves #44 

**Changes**

Permissions for copied files are now set explicitly. 
