### PR TITLE
[Bugfix] fixed overwriting of exposed ports

### DIFF
--- a/core/src/main/java/com/hivemq/testcontainer/core/HiveMQTestContainerCore.java
+++ b/core/src/main/java/com/hivemq/testcontainer/core/HiveMQTestContainerCore.java
@@ -76,7 +76,7 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
 
     public HiveMQTestContainerCore(final @NotNull String image, final @NotNull String tag) {
         super(image + ":" + tag);
-        withExposedPorts(MQTT_PORT);
+        addExposedPort(MQTT_PORT);
 
         waitStrategy.withRegEx("(.*)Started HiveMQ in(.*)");
         waitingFor(waitStrategy);
@@ -135,8 +135,8 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
      * @return self
      */
     public @NotNull SELF withDebugging(final int debuggingPortHost) {
-        withExposedPorts(DEBUGGING_PORT);
-        withFixedExposedPort(debuggingPortHost, DEBUGGING_PORT);
+        addExposedPorts(DEBUGGING_PORT);
+        addFixedExposedPort(debuggingPortHost, DEBUGGING_PORT);
         withEnv("JAVA_OPTS", "-agentlib:jdwp=transport=dt_socket,address=0.0.0.0:" + DEBUGGING_PORT + ",server=y,suspend=n");
         return self();
     }
@@ -610,8 +610,8 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
      * @return self
      */
     public @NotNull SELF withControlCenter(final int controlCenterPort) {
-        withExposedPorts(CONTROL_CENTER_PORT);
-        withFixedExposedPort(controlCenterPort, CONTROL_CENTER_PORT);
+        addExposedPorts(CONTROL_CENTER_PORT);
+        addFixedExposedPort(controlCenterPort, CONTROL_CENTER_PORT);
         return self();
     }
 

--- a/junit4/src/test/java/com/hivemq/testcontainer/junit4/DebuggingIT.java
+++ b/junit4/src/test/java/com/hivemq/testcontainer/junit4/DebuggingIT.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.testcontainer.junit4;
 
+import com.hivemq.client.mqtt.mqtt3.Mqtt3BlockingClient;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
 import com.hivemq.testcontainer.core.HiveMQExtension;
 import com.hivemq.testcontainer.util.MyExtension;
 import org.junit.Test;
@@ -46,6 +48,10 @@ public class DebuggingIT {
         rule.start();
         final Socket localhost = new Socket("localhost", 9000);
         localhost.close();
+
+        final Mqtt3BlockingClient client = Mqtt3Client.builder().serverPort(rule.getMqttPort()).buildBlocking();
+        client.connect();
+        client.disconnect();
         rule.stop();
     }
 

--- a/junit5/src/test/java/com/hivemq/testcontainer/junit5/DebuggingIT.java
+++ b/junit5/src/test/java/com/hivemq/testcontainer/junit5/DebuggingIT.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.testcontainer.junit5;
 
+import com.hivemq.client.mqtt.mqtt3.Mqtt3BlockingClient;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
 import com.hivemq.testcontainer.core.HiveMQExtension;
 import com.hivemq.testcontainer.util.MyExtension;
 import org.junit.jupiter.api.Test;
@@ -31,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class DebuggingIT {
 
-    public static final int DEBUGGING_PORT_HOST = 9000;
+    public static final int DEBUGGING_PORT_HOST = 5005;
 
     @Test()
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
@@ -47,8 +49,14 @@ public class DebuggingIT {
                         .withDebugging(DEBUGGING_PORT_HOST);
 
         extension.beforeEach(null);
-        final Socket localhost = new Socket("localhost", 9000);
+
+        final Socket localhost = new Socket("localhost", DEBUGGING_PORT_HOST);
         localhost.close();
+
+        final Mqtt3BlockingClient client = Mqtt3Client.builder().serverPort(extension.getMqttPort()).buildBlocking();
+        client.connect();
+        client.disconnect();
+
         extension.afterEach(null);
     }
 


### PR DESCRIPTION
**Motivation**

Using the `.withDebugging()` method caused the container to overwrite existing port mappings.

**Changes**

changed `withExposedPort` to `addExposedPort` where necessary. 