### PR TITLE
[Bugfix] reset wait strategy

### DIFF
--- a/core/src/main/java/com/hivemq/testcontainer/core/HiveMQTestContainerCore.java
+++ b/core/src/main/java/com/hivemq/testcontainer/core/HiveMQTestContainerCore.java
@@ -667,6 +667,12 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
         return this.getMappedPort(MQTT_PORT);
     }
 
+    @Override
+    public void stop() {
+        waitStrategy.reset();
+        super.stop();
+    }
+
     protected void signExtension(final @NotNull String extensionId, final @NotNull File jar) {
         // NOOP
     }

--- a/core/src/main/java/com/hivemq/testcontainer/core/MultiLogMessageWaitStrategy.java
+++ b/core/src/main/java/com/hivemq/testcontainer/core/MultiLogMessageWaitStrategy.java
@@ -23,6 +23,7 @@ import org.testcontainers.containers.output.WaitingConsumer;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
 import org.testcontainers.utility.LogUtils;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -70,7 +71,9 @@ class MultiLogMessageWaitStrategy extends AbstractWaitStrategy {
     }
 
     public @NotNull MultiLogMessageWaitStrategy reset() {
-        regexes.clear();
+        for (final Map.Entry<String, Boolean> stringBooleanEntry : regexes.entrySet()) {
+            stringBooleanEntry.setValue(false);
+        }
         return this;
     }
 }

--- a/core/src/main/java/com/hivemq/testcontainer/core/MultiLogMessageWaitStrategy.java
+++ b/core/src/main/java/com/hivemq/testcontainer/core/MultiLogMessageWaitStrategy.java
@@ -68,4 +68,9 @@ class MultiLogMessageWaitStrategy extends AbstractWaitStrategy {
         regexes.put(regEx, false);
         return this;
     }
+
+    public @NotNull MultiLogMessageWaitStrategy reset() {
+        regexes.clear();
+        return this;
+    }
 }

--- a/junit4/src/test/java/com/hivemq/testcontainer/junit4/ContainerWithExtensionIT.java
+++ b/junit4/src/test/java/com/hivemq/testcontainer/junit4/ContainerWithExtensionIT.java
@@ -15,10 +15,10 @@
  */
 package com.hivemq.testcontainer.junit4;
 
-import org.jetbrains.annotations.NotNull;
 import com.hivemq.testcontainer.core.HiveMQExtension;
 import com.hivemq.testcontainer.util.MyExtension;
 import com.hivemq.testcontainer.util.TestPublishModifiedUtil;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 /**
@@ -38,6 +38,14 @@ public class ContainerWithExtensionIT {
                 new HiveMQTestContainerRule()
                         .waitForExtension(hiveMQExtension)
                         .withExtension(hiveMQExtension);
+
+        rule.start();
+        TestPublishModifiedUtil.testPublishModified(rule.getMqttPort());
+        rule.stop();
+
+        rule.start();
+        TestPublishModifiedUtil.testPublishModified(rule.getMqttPort());
+        rule.stop();
 
         rule.start();
         TestPublishModifiedUtil.testPublishModified(rule.getMqttPort());

--- a/junit5/src/test/java/com/hivemq/testcontainer/junit5/ContainerWithExtensionIT.java
+++ b/junit5/src/test/java/com/hivemq/testcontainer/junit5/ContainerWithExtensionIT.java
@@ -45,5 +45,13 @@ public class ContainerWithExtensionIT {
         extension.beforeEach(null);
         TestPublishModifiedUtil.testPublishModified(extension.getMqttPort());
         extension.afterEach(null);
+
+        extension.beforeEach(null);
+        TestPublishModifiedUtil.testPublishModified(extension.getMqttPort());
+        extension.afterEach(null);
+
+        extension.beforeEach(null);
+        TestPublishModifiedUtil.testPublishModified(extension.getMqttPort());
+        extension.afterEach(null);
     }
 }


### PR DESCRIPTION
**Motivation**

It is currently not possible to restart, the container because the MultiMessageWaitStrategy is not properly reset and uses the status from the previous run.

**Changes**
Added explicit reset of the WaitStrategy when the container stops. 
