### PR TITLE
[Version 2.0.0] Improved Control Center 

### DIFF
--- a/junit4/src/test/java/com/hivemq/testcontainer/junit4/ContainerWithControlCenterIT.java
+++ b/junit4/src/test/java/com/hivemq/testcontainer/junit4/ContainerWithControlCenterIT.java
@@ -29,12 +29,12 @@ public class ContainerWithControlCenterIT {
     public void test() throws Exception {
         final HiveMQTestContainerRule rule =
                 new HiveMQTestContainerRule("hivemq/hivemq4", "latest")
-                        .withControlCenter(CONTROL_CENTER_PORT);
+                        .withControlCenter();
 
         rule.start();
 
         final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-        final HttpUriRequest request = new HttpGet("http://localhost:" + CONTROL_CENTER_PORT);
+        final HttpUriRequest request = new HttpGet("http://localhost:" + rule.getMappedPort(CONTROL_CENTER_PORT));
         httpClient.execute(request);
 
         rule.stop();

--- a/junit5/src/test/java/com/hivemq/testcontainer/junit5/ContainerWithControlCenterIT.java
+++ b/junit5/src/test/java/com/hivemq/testcontainer/junit5/ContainerWithControlCenterIT.java
@@ -34,12 +34,12 @@ public class ContainerWithControlCenterIT {
 
         final HiveMQTestContainerExtension extension =
                 new HiveMQTestContainerExtension("hivemq/hivemq4", "latest")
-                        .withControlCenter(CONTROL_CENTER_PORT);
+                        .withControlCenter();
 
         extension.beforeEach(null);
 
         final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-        final HttpUriRequest request = new HttpGet("http://localhost:" + CONTROL_CENTER_PORT);
+        final HttpUriRequest request = new HttpGet("http://localhost:" + extension.getMappedPort(CONTROL_CENTER_PORT));
         httpClient.execute(request);
 
         extension.afterEach(null);

--- a/readme.md
+++ b/readme.md
@@ -546,7 +546,7 @@ public final @NotNull HiveMQTestContainerExtension extension =
 
 ## Set Control Center Port
 
-You can set the HiveMQ Control Center port on the host machine that is mapped to the control center port inside the container.
+The HiveMQ Testcontainer allows you to access the HiveMQ Control Center.
 Note that the HiveMQ Control Center is feature of the HiveMQ Enterprise Edition.
 
 ### JUnit 4
@@ -555,7 +555,7 @@ Note that the HiveMQ Control Center is feature of the HiveMQ Enterprise Edition.
 @Rule
 public @NotNull HiveMQTestContainerRule rule = 
     new HiveMQTestContainerRule("hivemq/hivemq4", "latest")
-        .withControlCenter(CONTROL_CENTER_PORT);
+        .withControlCenter();
 ```
         
 ### JUnit 5
@@ -564,7 +564,13 @@ public @NotNull HiveMQTestContainerRule rule =
 @RegisterExtension
 public @NotNull HiveMQTestContainerExtension extension = 
     new HiveMQTestContainerExtension("hivemq/hivemq4", "latest")
-        .withControlCenter(CONTROL_CENTER_PORT);
+        .withControlCenter();
+```
+
+After startup, you are presented with the URL of the HiveMQ Control Center:
+
+```
+2021-09-10 10:35:53,511 INFO  - The HiveMQ Control Center is reachable under: http://localhost:55032
 ```
 
 ## Debug directly loaded extensions

--- a/readme.md
+++ b/readme.md
@@ -547,7 +547,7 @@ public final @NotNull HiveMQTestContainerExtension extension =
 ## Set Control Center Port
 
 The HiveMQ Testcontainer allows you to access the HiveMQ Control Center.
-Note that the HiveMQ Control Center is feature of the HiveMQ Enterprise Edition.
+Note that the HiveMQ Control Center is a feature of the HiveMQ Enterprise Edition.
 
 ### JUnit 4
 


### PR DESCRIPTION
**Motivation**

Smoothed accessing the HiveMQ Control Center

**Changes**

- The user no longer needs to provide a port for the control center. 
- The control Center URL will be printed upon Control Center startup
