### PR TITLE
Support custom dockerContainer waitStrategy on HiveMQTestContainerCore

### DIFF
--- a/core/src/main/java/com/hivemq/testcontainer/core/HiveMQTestContainerCore.java
+++ b/core/src/main/java/com/hivemq/testcontainer/core/HiveMQTestContainerCore.java
@@ -66,6 +66,7 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
                     "</hivemq-extension>";
 
     private static final @NotNull String DEFAULT_HIVEMQ_IMAGE = "hivemq/hivemq-ce";
+    private static final String HIVEMQ_CE_STARTED_LOG_REGEXP = "(.*)Started HiveMQ in(.*)";
     private static final @NotNull String DEFAULT_HIVEMQ_TAG = "latest";
     public static final int DEBUGGING_PORT = 9000;
     public static final int MQTT_PORT = 1883;
@@ -85,10 +86,14 @@ public class HiveMQTestContainerCore<SELF extends HiveMQTestContainerCore<SELF>>
     }
 
     public HiveMQTestContainerCore(final @NotNull DockerImageName dockerImageName) {
+        this(dockerImageName, HIVEMQ_CE_STARTED_LOG_REGEXP);
+    }
+
+    public HiveMQTestContainerCore(final @NotNull DockerImageName dockerImageName, String waitStrategyLogRegExp) {
         super(dockerImageName);
         addExposedPort(MQTT_PORT);
 
-        waitStrategy.withRegEx("(.*)Started HiveMQ in(.*)");
+        waitStrategy.withRegEx(waitStrategyLogRegExp);
         waitingFor(waitStrategy);
 
         withLogConsumer(outputFrame -> {

--- a/core/src/test/java/com/hivemq/testcontainer/core/HiveMQTestContainerCoreTest.java
+++ b/core/src/test/java/com/hivemq/testcontainer/core/HiveMQTestContainerCoreTest.java
@@ -15,17 +15,19 @@
  */
 package com.hivemq.testcontainer.core;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Yannick Weber
@@ -94,5 +96,18 @@ class HiveMQTestContainerCoreTest {
     void withFileInExtensionHomeFolder_fileDoesNotExist_Exception() {
         final MountableFile mountableFile = MountableFile.forHostPath("/this/does/not/exist");
         assertThrows(ContainerLaunchException.class, () -> container.withFileInExtensionHomeFolder(mountableFile, "my-extension"));
+    }
+
+    @Test
+    void customWaitStrategy() {
+        try {
+            HiveMQTestContainerCore container = new HiveMQTestContainerCore(DockerImageName.parse("hivemq/hivemq-edge"), "(.*)Started HiveMQ Edge in(.*)");
+            container.start();
+            InspectContainerResponse containerState = container.getContainerInfo();
+            assertNotNull(containerState.getId());
+
+        } finally {
+            container.stop();
+        }
     }
 }


### PR DESCRIPTION
**Motivation**

Currently, I am not able to load "hivemq/hivemq-edge" container due to a hardcoded "waitStrategy"